### PR TITLE
Allow setting total size from options

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function requestProgress(request, options) {
 
     // On response handler
     onResponse = function (response) {
-        totalSize = Number(response.headers['content-length']);
+        totalSize = Number(response.headers['content-length'] || options.totalSize);
         receivedSize = 0;
 
         // Note that the totalSize might not be available


### PR DESCRIPTION
This is useful if you know the size beforehand but the HTTP endpoint
doesn't send a Content-Length header, or if it sends a custom header
containing the size (often needed in some cases).