### PR TITLE
Allow getting length from a custom HTTP header

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function requestProgress(request, options) {
     options = options || {};
     options.throttle = options.throttle == null ? 1000 : options.throttle;
     options.delay = options.delay || 0;
+    options.lengthHeader = options.lengthHeader || 'content-length';
 
     // Throttle the progress report function
     reporter = throttle(function () {
@@ -36,7 +37,7 @@ function requestProgress(request, options) {
 
     // On response handler
     onResponse = function (response) {
-        totalSize = Number(response.headers['content-length']);
+        totalSize = Number(response.headers[options.lengthHeader]);
         receivedSize = 0;
 
         // Note that the totalSize might not be available


### PR DESCRIPTION
There are some cases (usually involving compression) in which you have
to specify the content length as a custom HTTP header in order to not
confuse web browsers.

This PR includes a new option `lengthHeader` that allows customising the
HTTP header where content length is read from.

Example:

```js
progress(request({ ... }), {
  lengthHeader: 'x-transfer-length'
});
```