### PR TITLE
Add eta support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "4.0"
+  - "0.12"
   - "0.10"
-  - "0.8"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ progress(request('http://google.com/doodle.png'), {
     // the content-length header
     console.log('total size in bytes', state.total);
     console.log('percent', state.percent);
+    console.log('eta', state.eta);
 })
 .on('error', function (err) {
     // Do something with err

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var throttle = require('throttleit');
+var Eta = require('node-eta');
 
 function requestProgress(request, options) {
     var reporter;
@@ -10,6 +11,7 @@ function requestProgress(request, options) {
     var totalSize;
     var previousReceivedSize;
     var receivedSize = 0;
+    var eta;
     var state = {};
 
     options = options || {};
@@ -27,6 +29,12 @@ function requestProgress(request, options) {
         previousReceivedSize = receivedSize;
         state.received = receivedSize;
 
+        // Update eta
+        if (totalSize) {
+            eta.done = state.received;
+            state.eta = Math.floor(eta.getEtaInSeconds());
+        }
+
         // Update percentage
         // Note that the totalSize might not be available
         state.percent = totalSize ? Math.round(receivedSize / totalSize * 100) : null;
@@ -41,6 +49,11 @@ function requestProgress(request, options) {
 
         // Note that the totalSize might not be available
         state.total = totalSize || null;
+
+        if (totalSize) {
+            eta = new Eta(state.total);
+            eta.start();
+        }
 
         // Delay the progress report
         delayCompleted = false;

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Tracks the download progress of a request made with mikeal/request",
   "main": "index.js",
   "dependencies": {
-    "node-eta": "~0.1.1",
-    "throttleit": "~0.0.2"
+    "node-eta": "^0.1.1",
+    "throttleit": "^0.0.2"
   },
   "devDependencies": {
-    "mocha": "~1.12.0",
-    "expect.js": "~0.2.0"
+    "mocha": "^1.12.0",
+    "expect.js": "^0.2.0"
   },
   "scripts": {
     "test": "mocha -R spec"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Tracks the download progress of a request made with mikeal/request",
   "main": "index.js",
   "dependencies": {
+    "node-eta": "~0.1.1",
     "throttleit": "~0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The `state` object now contains an `eta` property which equals the
estimated time for completion *in seconds*.

The `eta` is not calculated if there is no total size detected.

See https://github.com/titarenko/eta

Fixes: https://github.com/IndigoUnited/node-request-progress/issues/7