### PR TITLE
Add gzip support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
 script: "npm run test-travis"

--- a/index.js
+++ b/index.js
@@ -113,8 +113,10 @@ function requestProgress(request, options) {
     // Attach listeners
     request
     .on('request', onRequest.bind(null, context))
-    .on('response', onResponse.bind(null, context))
-    .on('data', onData.bind(null, context))
+    .on('response', function handleResponse(response) {
+        response.on('data', onData.bind(null, context));
+        return onResponse(context, response);
+    })
     .on('end', onEnd.bind(null, context));
 
     request.progressContext = context;

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ function requestProgress(request, options) {
     .on('request', onRequest.bind(null, context))
     .on('response', function handleResponse(response) {
         response.on('data', onData.bind(null, context));
+        
         return onResponse(context, response);
     })
     .on('end', onEnd.bind(null, context));

--- a/test/test.js
+++ b/test/test.js
@@ -15,10 +15,12 @@ function normalizeStates(states) {
 describe('request-progress', function () {
     var request;
     var states;
+    var response;
 
     beforeEach(function () {
         states = [];
         request = new EventEmitter();
+        response = new EventEmitter();
 
         request.on('progress', function (state) {
             states.push(JSON.parse(JSON.stringify(state)));
@@ -51,18 +53,19 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 10 } });
+        response.headers = { 'content-length': 10 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aaaaa'));
+            response.emit('data', new Buffer('aaaaa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bbb'));
+            response.emit('data', new Buffer('bbb'));
         }, 1150);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('cc'));
+            response.emit('data', new Buffer('cc'));
             request.emit('end');
         }, 1250);
     });
@@ -79,20 +82,21 @@ describe('request-progress', function () {
         expect(request.progressState).to.be(undefined);
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 2 } });
+        response.headers = { 'content-length': 2 };
+        request.emit('response', response);
 
         expect(request.progressContext).to.be.an('object');
         expect(request.progressState).to.be.an('object');
 
         setTimeout(function () {
-            request.emit('data', new Buffer('a'));
+            response.emit('data', new Buffer('a'));
             expect(request.progressContext).to.be.an('object');
             expect(request.progressState).to.be.an('object');
             expect(request.progressState.percentage).to.be(0.5);
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('b'));
+            response.emit('data', new Buffer('b'));
             expect(request.progressContext).to.be.an('object');
             expect(request.progressState).to.be.an('object');
             expect(request.progressState.percentage).to.be(1);
@@ -116,22 +120,23 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 10 } });
+        response.headers = { 'content-length': 10 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aa'));
+            response.emit('data', new Buffer('aa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bb'));
+            response.emit('data', new Buffer('bb'));
         }, 200);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('cc'));
+            response.emit('data', new Buffer('cc'));
         }, 300);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('dddd'));
+            response.emit('data', new Buffer('dddd'));
             request.emit('end');
         }, 400);
     });
@@ -153,30 +158,31 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 10 } });
+        response.headers = { 'content-length': 10 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aa'));
+            response.emit('data', new Buffer('aa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bb'));
+            response.emit('data', new Buffer('bb'));
         }, 100);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('cc'));
+            response.emit('data', new Buffer('cc'));
         }, 300);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('dd'));
+            response.emit('data', new Buffer('dd'));
         }, 400);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('e'));
+            response.emit('data', new Buffer('e'));
         }, 500);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bf'));
+            response.emit('data', new Buffer('bf'));
             request.emit('end');
         }, 700);
     });
@@ -202,16 +208,15 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', {
-            headers: { 'x-transfer-length': 10, 'content-length': 5 }
-        });
+        response.headers = { 'x-transfer-length': 10, 'content-length': 5 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aaaaa'));
+            response.emit('data', new Buffer('aaaaa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bbbbb'));
+            response.emit('data', new Buffer('bbbbb'));
             request.emit('end');
         }, 200);
     });
@@ -245,14 +250,15 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', { headers: {} });
+        response.headers = {};
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aaaaa'));
+            response.emit('data', new Buffer('aaaaa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bbbbbbb'));
+            response.emit('data', new Buffer('bbbbbbb'));
             request.emit('end');
         }, 1150);
     });
@@ -278,14 +284,15 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 10 } });
+        response.headers = { 'content-length': 10 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aaaaa'));
+            response.emit('data', new Buffer('aaaaa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bbbbbbb'));
+            response.emit('data', new Buffer('bbbbbbb'));
             request.emit('end');
         }, 1150);
     });
@@ -294,14 +301,15 @@ describe('request-progress', function () {
         progress(request, { throttle: 100 });
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 10 } });
+        response.headers = { 'content-length': 10 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aa'));
+            response.emit('data', new Buffer('aa'));
         }, 25);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('bbbbbbbb'));
+            response.emit('data', new Buffer('bbbbbbbb'));
             request.emit('end');
         }, 50);
 
@@ -326,10 +334,11 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 2 } });
+        response.headers = { 'content-length': 2 };
+        request.emit('response', response);
 
         setTimeout(function () {
-            request.emit('data', new Buffer('aa'));
+            response.emit('data', new Buffer('aa'));
             request.emit('end');
         }, 25);
     });
@@ -341,7 +350,8 @@ describe('request-progress', function () {
         expect(request.progressState).to.be(undefined);
 
         request.emit('request');
-        request.emit('response', { headers: { 'content-length': 2 } });
+        response.headers = { 'content-length': 2 };
+        request.emit('response', response);
 
         expect(request.progressContext).to.be.an('object');
         expect(request.progressState).to.be.an('object');
@@ -350,5 +360,33 @@ describe('request-progress', function () {
 
         expect(request.progressContext).to.be.an('object');
         expect(request.progressState).to.be(null);
+    });
+
+    it('should ignore "data" event from the request', function (done) {
+        progress(request, { throttle: 0 })
+            .on('end', function () {
+                expect(states).to.have.length(2);
+                expect(states[0].percentage).to.be(0.5);
+                expect(states[1].percentage).to.be(1);
+
+                done();
+            });
+
+        request.emit('request');
+        response.headers = { 'content-length': 4 };
+        request.emit('response', response);
+
+        setTimeout(function () {
+            response.emit('data', new Buffer('aa'));
+        }, 25);
+
+        setTimeout(function () {
+            request.emit('data', new Buffer('aa'));
+        }, 50);
+
+        setTimeout(function () {
+            response.emit('data', new Buffer('aa'));
+            request.emit('end');
+        }, 100);
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -53,8 +53,7 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = { 'content-length': 10 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 10 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aaaaa'));
@@ -82,8 +81,7 @@ describe('request-progress', function () {
         expect(request.progressState).to.be(undefined);
 
         request.emit('request');
-        response.headers = { 'content-length': 2 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 2 } }));
 
         expect(request.progressContext).to.be.an('object');
         expect(request.progressState).to.be.an('object');
@@ -120,8 +118,7 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = { 'content-length': 10 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 10 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aa'));
@@ -158,8 +155,7 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = { 'content-length': 10 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 10 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aa'));
@@ -208,8 +204,9 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = { 'x-transfer-length': 10, 'content-length': 5 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, {
+            headers: { 'x-transfer-length': 10, 'content-length': 5 }
+        }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aaaaa'));
@@ -250,8 +247,7 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = {};
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: {} }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aaaaa'));
@@ -285,7 +281,7 @@ describe('request-progress', function () {
 
         request.emit('request');
         response.headers = { 'content-length': 10 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 10 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aaaaa'));
@@ -334,8 +330,7 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = { 'content-length': 2 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 2 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aa'));
@@ -350,8 +345,7 @@ describe('request-progress', function () {
         expect(request.progressState).to.be(undefined);
 
         request.emit('request');
-        response.headers = { 'content-length': 2 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 2 } }));
 
         expect(request.progressContext).to.be.an('object');
         expect(request.progressState).to.be.an('object');
@@ -364,7 +358,7 @@ describe('request-progress', function () {
 
     it('should hook into "data" event from the response and not the request', function (done) {
         // See: https://github.com/IndigoUnited/node-request-progress/issues/20
-        
+
         progress(request, { throttle: 0 })
             .on('end', function () {
                 expect(states).to.have.length(2);
@@ -375,8 +369,7 @@ describe('request-progress', function () {
             });
 
         request.emit('request');
-        response.headers = { 'content-length': 4 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 4 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aa'));

--- a/test/test.js
+++ b/test/test.js
@@ -362,7 +362,9 @@ describe('request-progress', function () {
         expect(request.progressState).to.be(null);
     });
 
-    it('should ignore "data" event from the request', function (done) {
+    it('should hook into "data" event from the response and not the request', function (done) {
+        // See: https://github.com/IndigoUnited/node-request-progress/issues/20
+        
         progress(request, { throttle: 0 })
             .on('end', function () {
                 expect(states).to.have.length(2);

--- a/test/test.js
+++ b/test/test.js
@@ -280,7 +280,6 @@ describe('request-progress', function () {
         });
 
         request.emit('request');
-        response.headers = { 'content-length': 10 };
         request.emit('response', Object.assign(response, { headers: { 'content-length': 10 } }));
 
         setTimeout(function () {
@@ -297,8 +296,7 @@ describe('request-progress', function () {
         progress(request, { throttle: 100 });
 
         request.emit('request');
-        response.headers = { 'content-length': 10 };
-        request.emit('response', response);
+        request.emit('response', Object.assign(response, { headers: { 'content-length': 10 } }));
 
         setTimeout(function () {
             response.emit('data', new Buffer('aa'));


### PR DESCRIPTION
This fixes #20 issue with the flag `{ gzip: true}`!

The problem was that listening to the `request.on('data')` would give us the uncompressed data stream, thus ruining the size calculation of the download.

By listening to `response.on('data')` instead, we get the raw compressed data stream, and the size calculation adds up correctly!